### PR TITLE
Update pep8 checker workflows, broken link checker workflow to use "v3" branch, specify python version as input argument

### DIFF
--- a/.github/workflows/pep8_nb_style_check.yml
+++ b/.github/workflows/pep8_nb_style_check.yml
@@ -11,4 +11,6 @@ on:
 
 jobs:
   Notebook_PEP8_Check:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/notebook_pep8check.yml@main
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/notebook_pep8check.yml@v3
+   with:
+      python-version: ${{ vars.PYTHON_VERSION }}

--- a/.github/workflows/pep8_script_style_check.yml
+++ b/.github/workflows/pep8_script_style_check.yml
@@ -11,4 +11,6 @@ on:
 
 jobs:
   Script_PEP8_Check:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/script_pep8check.yml@main
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/script_pep8check.yml@v3
+   with:
+      python-version: ${{ vars.PYTHON_VERSION }}

--- a/.github/workflows/weekly_broken_link_finder.yml
+++ b/.github/workflows/weekly_broken_link_finder.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   Scheduled:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/broken_link_checker.yml@main
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/broken_link_checker.yml@v3
    with:
      website_url: "https://spacetelescope.github.io/hellouniverse/intro.html"


### PR DESCRIPTION
**Relevant Tickets and PRs**
- [SPB-1792](https://jira.stsci.edu/browse/SPB-1792)
- [notebook-ci-actions PR #21](https://github.com/spacetelescope/notebook-ci-actions/pull/21)

**Summary of Changes**
- Updated the following workflows to execute the "v3" branch workflows:
  - pep8_nb_style_check.yml
  - pep8_script_style_check.yml
  - broken_link_checker.yml
- Added required input argument to the following workflows:
  - pep8_nb_style_check.yml
  - pep8_script_style_check.yml