### PR TITLE
Fix keras version in TESS classify notebook

### DIFF
--- a/notebooks/hello-universe/Classifying_TESS_flares_with_CNNs/requirements.txt
+++ b/notebooks/hello-universe/Classifying_TESS_flares_with_CNNs/requirements.txt
@@ -1,6 +1,6 @@
 tensorflow
 astropy>=6.0.0
-keras
+keras==2.8.0
 lightkurve>=2.4.2
 matplotlib>=3.8.2
 numpy>=1.26.2


### PR DESCRIPTION
Keras 3.0 can't open older .h5 model files, so fixing the version of keras to avoid needing to update all of the related HLSP files. 