### PR TITLE
Try again to update requirements file for stella notebook

### DIFF
--- a/notebooks/hello-universe/Classifying_TESS_flares_with_CNNs/requirements.txt
+++ b/notebooks/hello-universe/Classifying_TESS_flares_with_CNNs/requirements.txt
@@ -1,6 +1,6 @@
-tensorflow
+tensorflow==2.15.1
 astropy>=6.0.0
-keras==2.8.0
+keras==2.16
 lightkurve>=2.4.2
 matplotlib>=3.8.2
 numpy>=1.26.2


### PR DESCRIPTION
Attempt number 2 to fix the dependency issues with the `stella` notebook (balancing the need for keras version <3.0 to accommodate loading old trained models stored as HLSP with the need to have keras and tensorflow work together. 